### PR TITLE
Add mcpe version cards to fragments

### DIFF
--- a/app/src/main/java/com/origin/launcher/VersionsBetaFragment.java
+++ b/app/src/main/java/com/origin/launcher/VersionsBetaFragment.java
@@ -6,18 +6,37 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.fragment.app.Fragment;
 import android.util.Log;
 import com.google.android.material.card.MaterialCardView;
+import com.google.android.material.button.MaterialButton;
 
 public class VersionsBetaFragment extends BaseThemedFragment {
 
+    private LinearLayout versionsContainer;
+    private java.util.List<VersionItem> versionItems;
+
+    private static class VersionItem {
+        String name;
+        String description;
+        String downloadUrl;
+        VersionItem(String name, String description, String downloadUrl) {
+            this.name = name;
+            this.description = description;
+            this.downloadUrl = downloadUrl;
+        }
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_versions_beta, container, false);
         
+        versionsContainer = view.findViewById(R.id.versionsContainerBeta);
+        initializeVersions();
+        populateVersionCards();
         
         return view;
     }
@@ -32,5 +51,120 @@ public class VersionsBetaFragment extends BaseThemedFragment {
     public void onPause() {
         super.onPause();
         DiscordRPCHelper.getInstance().updateIdlePresence();
+    }
+
+    private void initializeVersions() {
+        versionItems = new java.util.ArrayList<>();
+        // Sample beta MCPE versions; replace URLs with real downloads as needed
+        versionItems.add(new VersionItem("1.21.40.23", "Beta preview build", "https://example.com/mcpe/beta/1.21.40.23.apk"));
+        versionItems.add(new VersionItem("1.21.40.20", "Beta changes and fixes", "https://example.com/mcpe/beta/1.21.40.20.apk"));
+    }
+
+    private void populateVersionCards() {
+        if (versionsContainer == null) return;
+        versionsContainer.removeAllViews();
+        for (int i = 0; i < versionItems.size(); i++) {
+            View card = createVersionCard(versionItems.get(i));
+            versionsContainer.addView(card);
+            if (i < versionItems.size() - 1) {
+                View spacer = new View(requireContext());
+                LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    (int) (12 * getResources().getDisplayMetrics().density)
+                );
+                spacer.setLayoutParams(params);
+                versionsContainer.addView(spacer);
+            }
+        }
+    }
+
+    private View createVersionCard(VersionItem item) {
+        MaterialCardView card = new MaterialCardView(requireContext());
+        LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        card.setLayoutParams(cardParams);
+        card.setRadius(12 * getResources().getDisplayMetrics().density);
+        card.setCardElevation(0);
+        card.setClickable(true);
+        card.setFocusable(true);
+        ThemeUtils.applyThemeToCard(card, requireContext());
+        card.setStrokeWidth((int) (1 * getResources().getDisplayMetrics().density));
+
+        LinearLayout mainLayout = new LinearLayout(requireContext());
+        mainLayout.setOrientation(LinearLayout.HORIZONTAL);
+        mainLayout.setPadding(
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density)
+        );
+        mainLayout.setGravity(android.view.Gravity.CENTER_VERTICAL);
+
+        LinearLayout textLayout = new LinearLayout(requireContext());
+        textLayout.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
+            0,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            1.0f
+        );
+        textLayout.setLayoutParams(textParams);
+
+        TextView nameText = new TextView(requireContext());
+        nameText.setText("MCPE " + item.name);
+        nameText.setTextSize(16);
+        nameText.setTypeface(null, android.graphics.Typeface.BOLD);
+        ThemeUtils.applyThemeToTextView(nameText, "onSurface");
+
+        TextView descText = new TextView(requireContext());
+        descText.setText(item.description);
+        descText.setTextSize(14);
+        ThemeUtils.applyThemeToTextView(descText, "onSurfaceVariant");
+        LinearLayout.LayoutParams descParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        descParams.topMargin = (int) (8 * getResources().getDisplayMetrics().density);
+        descText.setLayoutParams(descParams);
+
+        textLayout.addView(nameText);
+        textLayout.addView(descText);
+
+        LinearLayout rightContainer = new LinearLayout(requireContext());
+        rightContainer.setOrientation(LinearLayout.HORIZONTAL);
+        rightContainer.setGravity(android.view.Gravity.CENTER_VERTICAL);
+        LinearLayout.LayoutParams rightParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        rightParams.setMarginStart((int) (16 * getResources().getDisplayMetrics().density));
+        rightContainer.setLayoutParams(rightParams);
+
+        MaterialButton downloadButton = new MaterialButton(requireContext());
+        downloadButton.setText("Download");
+        ThemeUtils.applyThemeToButton(downloadButton, requireContext());
+        downloadButton.setOnClickListener(v -> openUrl(item.downloadUrl));
+
+        rightContainer.addView(downloadButton);
+        mainLayout.addView(textLayout);
+        mainLayout.addView(rightContainer);
+        card.addView(mainLayout);
+        return card;
+    }
+
+    private void openUrl(String url) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            startActivity(intent);
+        } catch (Exception e) {
+            Toast.makeText(requireContext(), "Unable to open link", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    @Override
+    protected void onApplyTheme() {
+        // Rebuild cards to refresh colors when theme changes
+        populateVersionCards();
     }
 }

--- a/app/src/main/java/com/origin/launcher/VersionsStableFragment.java
+++ b/app/src/main/java/com/origin/launcher/VersionsStableFragment.java
@@ -6,18 +6,37 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.fragment.app.Fragment;
 import android.util.Log;
 import com.google.android.material.card.MaterialCardView;
+import com.google.android.material.button.MaterialButton;
 
 public class VersionsStableFragment extends BaseThemedFragment {
 
+    private LinearLayout versionsContainer;
+    private java.util.List<VersionItem> versionItems;
+
+    private static class VersionItem {
+        String name;
+        String description;
+        String downloadUrl;
+        VersionItem(String name, String description, String downloadUrl) {
+            this.name = name;
+            this.description = description;
+            this.downloadUrl = downloadUrl;
+        }
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_versions_stable, container, false);
         
+        versionsContainer = view.findViewById(R.id.versionsContainerStable);
+        initializeVersions();
+        populateVersionCards();
         
         return view;
     }
@@ -32,5 +51,121 @@ public class VersionsStableFragment extends BaseThemedFragment {
     public void onPause() {
         super.onPause();
         DiscordRPCHelper.getInstance().updateIdlePresence();
+    }
+
+    private void initializeVersions() {
+        versionItems = new java.util.ArrayList<>();
+        // Sample stable MCPE versions; replace URLs with real downloads as needed
+        versionItems.add(new VersionItem("1.21.30", "Latest stable features and fixes", "https://example.com/mcpe/1.21.30.apk"));
+        versionItems.add(new VersionItem("1.21.20", "Stability improvements", "https://example.com/mcpe/1.21.20.apk"));
+        versionItems.add(new VersionItem("1.21.0", "1.21 release", "https://example.com/mcpe/1.21.0.apk"));
+    }
+
+    private void populateVersionCards() {
+        if (versionsContainer == null) return;
+        versionsContainer.removeAllViews();
+        for (int i = 0; i < versionItems.size(); i++) {
+            View card = createVersionCard(versionItems.get(i));
+            versionsContainer.addView(card);
+            if (i < versionItems.size() - 1) {
+                View spacer = new View(requireContext());
+                LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    (int) (12 * getResources().getDisplayMetrics().density)
+                );
+                spacer.setLayoutParams(params);
+                versionsContainer.addView(spacer);
+            }
+        }
+    }
+
+    private View createVersionCard(VersionItem item) {
+        MaterialCardView card = new MaterialCardView(requireContext());
+        LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        card.setLayoutParams(cardParams);
+        card.setRadius(12 * getResources().getDisplayMetrics().density);
+        card.setCardElevation(0);
+        card.setClickable(true);
+        card.setFocusable(true);
+        ThemeUtils.applyThemeToCard(card, requireContext());
+        card.setStrokeWidth((int) (1 * getResources().getDisplayMetrics().density));
+
+        LinearLayout mainLayout = new LinearLayout(requireContext());
+        mainLayout.setOrientation(LinearLayout.HORIZONTAL);
+        mainLayout.setPadding(
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density),
+            (int) (16 * getResources().getDisplayMetrics().density)
+        );
+        mainLayout.setGravity(android.view.Gravity.CENTER_VERTICAL);
+
+        LinearLayout textLayout = new LinearLayout(requireContext());
+        textLayout.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
+            0,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            1.0f
+        );
+        textLayout.setLayoutParams(textParams);
+
+        TextView nameText = new TextView(requireContext());
+        nameText.setText("MCPE " + item.name);
+        nameText.setTextSize(16);
+        nameText.setTypeface(null, android.graphics.Typeface.BOLD);
+        ThemeUtils.applyThemeToTextView(nameText, "onSurface");
+
+        TextView descText = new TextView(requireContext());
+        descText.setText(item.description);
+        descText.setTextSize(14);
+        ThemeUtils.applyThemeToTextView(descText, "onSurfaceVariant");
+        LinearLayout.LayoutParams descParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        descParams.topMargin = (int) (8 * getResources().getDisplayMetrics().density);
+        descText.setLayoutParams(descParams);
+
+        textLayout.addView(nameText);
+        textLayout.addView(descText);
+
+        LinearLayout rightContainer = new LinearLayout(requireContext());
+        rightContainer.setOrientation(LinearLayout.HORIZONTAL);
+        rightContainer.setGravity(android.view.Gravity.CENTER_VERTICAL);
+        LinearLayout.LayoutParams rightParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        rightParams.setMarginStart((int) (16 * getResources().getDisplayMetrics().density));
+        rightContainer.setLayoutParams(rightParams);
+
+        MaterialButton downloadButton = new MaterialButton(requireContext());
+        downloadButton.setText("Download");
+        ThemeUtils.applyThemeToButton(downloadButton, requireContext());
+        downloadButton.setOnClickListener(v -> openUrl(item.downloadUrl));
+
+        rightContainer.addView(downloadButton);
+        mainLayout.addView(textLayout);
+        mainLayout.addView(rightContainer);
+        card.addView(mainLayout);
+        return card;
+    }
+
+    private void openUrl(String url) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            startActivity(intent);
+        } catch (Exception e) {
+            Toast.makeText(requireContext(), "Unable to open link", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    @Override
+    protected void onApplyTheme() {
+        // Rebuild cards to refresh colors when theme changes
+        populateVersionCards();
     }
 }

--- a/app/src/main/res/layout/fragment_versions_beta.xml
+++ b/app/src/main/res/layout/fragment_versions_beta.xml
@@ -21,6 +21,12 @@
             android:textColor="@color/onBackground"
             android:layout_marginBottom="32dp"
             android:fontFamily="sans-serif-light" />
+
+        <LinearLayout
+            android:id="@+id/versionsContainerBeta"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/fragment_versions_stable.xml
+++ b/app/src/main/res/layout/fragment_versions_stable.xml
@@ -21,6 +21,12 @@
             android:textColor="@color/onBackground"
             android:layout_marginBottom="32dp"
             android:fontFamily="sans-serif-light" />
+
+        <LinearLayout
+            android:id="@+id/versionsContainerStable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
Add theme-aware MCPE version cards with download buttons to the stable and beta fragments.

This implements the requested feature to display MCPE versions and their download links, mirroring the existing card pattern and integrating with the app's theme system for consistent styling. Placeholder download URLs are currently used.

---
<a href="https://cursor.com/background-agent?bcId=bc-4adefb9d-9f7a-493e-ab07-742a41c30297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4adefb9d-9f7a-493e-ab07-742a41c30297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

